### PR TITLE
Fixed nested Environmental Variables issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+dist/
+.vscode/

--- a/envtoml/__init__.py
+++ b/envtoml/__init__.py
@@ -1,16 +1,16 @@
-__version__ = '0.1.2'
+__version__ = "0.1.3"
 
 import toml
 import os
 import re
 
-RE_ENV_VAR = r'\$([A-Z_][A-Z0-9_]+)'
+RE_ENV_VAR = r"\$([A-Z_][A-Z0-9_]+)"
 decoder = toml.TomlDecoder()
 
 
 def env_replace(x):
     env_var = x.groups()[0]
-    p = os.environ.get(env_var, '')
+    p = os.environ.get(env_var, "")
     return p
 
 
@@ -25,20 +25,24 @@ def process(item):
         if isinstance(val, (dict, list)):
             process(val)
         elif isinstance(val, str):
-            if re.match(RE_ENV_VAR, val):
-                r = re.sub(RE_ENV_VAR, env_replace, val)
+            matches = re.finditer(RE_ENV_VAR, val, re.MULTILINE)
+            if not matches:
+                continue
+            for match in matches:
+                if type(match) is re.Match:
+                    val = val.replace(match.group(), env_replace(match))
 
                 # Try to first load the value from the environment variable
                 # (i.e. make what seems like a float a float, what seems like a
                 # boolean a bool and so on). If that fails, fail back to
                 # string.
                 try:
-                    item[i], _ = decoder.load_value(r)
+                    item[i], _ = decoder.load_value(val)
                     continue
                 except ValueError:
                     pass
 
-                item[i], _ = decoder.load_value('"{}"'.format(r))
+                item[i], _ = decoder.load_value('"{}"'.format(val))
 
 
 def load(*args, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "envTOML"
-version = "0.1.2"
+version = "0.1.3"
 description = "A simple way of using environment variables in TOML configs (via interpolation)"
 authors = ["mr.Shu <mr@shu.io>"]
 license = "MIT"

--- a/tests/test_complex.toml
+++ b/tests/test_complex.toml
@@ -7,7 +7,7 @@ name = "orange"
 price = 3.14
 
 [[other]]
-name = "laptop"
+name = "laptop:1000"
 price = 1000
 sold = true
 

--- a/tests/test_complex_replacement.toml
+++ b/tests/test_complex_replacement.toml
@@ -7,7 +7,7 @@ name = "orange"
 price = 3.14
 
 [[other]]
-name = '$MY_LAPTOP_NAME'
+name = '$MY_LAPTOP_NAME:$MY_LAPTOP_PRICE'
 price = '$MY_LAPTOP_PRICE'
 sold = '$MY_IS_LAPTOP_SOLD'
 

--- a/tests/test_envtoml.py
+++ b/tests/test_envtoml.py
@@ -3,72 +3,70 @@ from envtoml import load, loads
 import os
 
 
-SIMPLE_OUTPUT = {'x': 5, 'y': 10}
+SIMPLE_OUTPUT = {"x": 5, "y": 10}
 MORE_COMPLEX_OUTPUT = {
-    'fruit': [
-        {'name': 'apple', 'price': 2},
-        {'name': 'orange', 'price': 3.14}
+    "fruit": [{"name": "apple", "price": 2}, {"name": "orange", "price": 3.14}],
+    "other": [
+        {"name": "laptop:1000", "price": 1000, "sold": True},
+        {"name": "phone", "price": 500},
     ],
-    'other': [
-        {'name': 'laptop', 'price': 1000, 'sold': True},
-        {'name': 'phone', 'price': 500}
-    ]
 }
 
 
 def test_version():
-    assert __version__ == '0.1.2'
+    assert __version__ == "0.1.3"
 
 
 def test_load():
-    assert load(open('./tests/test_simple.toml')) == SIMPLE_OUTPUT
-    assert load(open('./tests/test_complex.toml')) == MORE_COMPLEX_OUTPUT
+    assert load(open("./tests/test_simple.toml")) == SIMPLE_OUTPUT
+    assert load(open("./tests/test_complex.toml")) == MORE_COMPLEX_OUTPUT
 
 
 def test_load_with_replace():
-    os.environ['MY_CONFIG_VAR'] = "10"
-    assert load(open('./tests/test_simple_replacement.toml')) == SIMPLE_OUTPUT
+    os.environ["MY_CONFIG_VAR"] = "10"
+    assert load(open("./tests/test_simple_replacement.toml")) == SIMPLE_OUTPUT
 
 
 def test_loads():
-    assert loads('{x = 5, y = 10}') == SIMPLE_OUTPUT
+    assert loads("{x = 5, y = 10}") == SIMPLE_OUTPUT
 
 
 def test_loads_with_replace():
-    os.environ['MY_CONFIG_VAR'] = "10"
+    os.environ["MY_CONFIG_VAR"] = "10"
     assert loads("{x = 5, y = '$MY_CONFIG_VAR'}") == SIMPLE_OUTPUT
 
 
 def test_loads_with_replace_str():
-    os.environ['MY_STR_CONFIG_VAR'] = "Hello"
-    assert loads("{name = '$MY_STR_CONFIG_VAR'}") == {'name': 'Hello'}
+    os.environ["MY_STR_CONFIG_VAR"] = "Hello"
+    assert loads("{name = '$MY_STR_CONFIG_VAR'}") == {"name": "Hello"}
 
 
 def test_loads_with_replace_float():
-    os.environ['MY_FLOAT_CONFIG_VAR'] = "3.14"
-    assert loads("{val = '$MY_FLOAT_CONFIG_VAR'}") == {'val': 3.14}
+    os.environ["MY_FLOAT_CONFIG_VAR"] = "3.14"
+    assert loads("{val = '$MY_FLOAT_CONFIG_VAR'}") == {"val": 3.14}
 
 
 def test_loads_with_replace_bool():
-    os.environ['MY_BOOL_CONFIG_VAR'] = 'true'
-    assert loads("{is_set = '$MY_BOOL_CONFIG_VAR'}") == {'is_set': True}
+    os.environ["MY_BOOL_CONFIG_VAR"] = "true"
+    assert loads("{is_set = '$MY_BOOL_CONFIG_VAR'}") == {"is_set": True}
 
-    os.environ['MY_BOOL_CONFIG_VAR'] = 'false'
-    assert loads("{is_set = '$MY_BOOL_CONFIG_VAR'}") == {'is_set': False}
+    os.environ["MY_BOOL_CONFIG_VAR"] = "false"
+    assert loads("{is_set = '$MY_BOOL_CONFIG_VAR'}") == {"is_set": False}
 
 
 def test_complex_replacement():
-    os.environ['MY_LAPTOP_NAME'] = 'laptop'
-    os.environ['MY_LAPTOP_PRICE'] = '1000'
-    os.environ['MY_IS_LAPTOP_SOLD'] = 'true'
-
-    assert load(open('./tests/test_complex_replacement.toml')) == MORE_COMPLEX_OUTPUT # noqa
+    os.environ["MY_LAPTOP_NAME"] = "laptop"
+    os.environ["MY_LAPTOP_PRICE"] = "1000"
+    os.environ["MY_IS_LAPTOP_SOLD"] = "true"
+    assert (
+        load(open("./tests/test_complex_replacement.toml")) == MORE_COMPLEX_OUTPUT
+    )  # noqa
 
 
 def test_loads_with_replace_and_empty_value():
-    assert loads("{x = 5, y = '$NON_EXISTENT_VAR'}") == {'x': 5, 'y': ''}
+    assert loads("{x = 5, y = '$NON_EXISTENT_VAR'}") == {"x": 5, "y": ""}
 
 
 def test_loads_with_replace_dict():
-    os.environ['MY_CONFIG_VAR'] = "{z = 123}"
-    assert loads("{x = 5, y = '$MY_CONFIG_VAR'}") == {'x': 5, 'y': {'z': 123}}
+    os.environ["MY_CONFIG_VAR"] = "{z = 123}"
+    assert loads("{x = 5, y = '$MY_CONFIG_VAR'}") == {"x": 5, "y": {"z": 123}}


### PR DESCRIPTION
I also updated the version to reflect the changed and tested my new change.

Basically the issue I was having was when I went to add nested environmental variables to my `.toml` file.

IE:
``` toml
mongo-url = "mongodb://$MONGO_USER:$MONGO_PASS@mongo:$MONGO_PORT"
```

I found this important because I wanted to build a configuration from multiple environmental variables for a program that accepts configuration in the `toml` format.

My new way allows for multiple environmental variables on one line of configuration. I used `black` python formatter so some of the changes are because of it.