### PR TITLE
Add option to use mapping other than os.environ

### DIFF
--- a/envtoml/__init__.py
+++ b/envtoml/__init__.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 from datetime import date, datetime, time
+from collections.abc import MutableMapping
 from typing import Any, BinaryIO, Callable, Dict, List, Match, Optional, Union
 
 if sys.version_info >= (3, 11):
@@ -25,14 +26,21 @@ TOMLList = List['TOMLValue']
 TOMLPrimitive = Union[str, int, float, bool, datetime, date, time]
 TOMLValue = Union[TOMLPrimitive, TOMLDict, TOMLList]
 ParseFloat = Callable[[str], float]
+EnvironMap = Optional[MutableMapping[str, str]]
 
 
-def env_replace(match: Match[str], fail_on_missing: bool) -> str:
+def env_replace(
+    match: Match[str],
+    fail_on_missing: bool,
+    env_values: EnvironMap,
+) -> str:
     if match.group(0) == '$$':
         return '$'
     env_var = match.group('simple') or match.group('braced')
     default = match.group('default')
-    value = os.environ.get(env_var)
+    if env_values is None:
+        env_values = os.environ
+    value = env_values.get(env_var)
     if value:
         return value
     if default is not None:
@@ -51,13 +59,14 @@ def _replace_env_value(
     value: str,
     parse_float: ParseFloat,
     fail_on_missing: bool,
+    env_values: EnvironMap
 ) -> Optional[TOMLValue]:
     if not re.search(RE_ENV_VAR, value):
         return None
 
     replaced = re.sub(
         RE_ENV_VAR,
-        lambda match: env_replace(match, fail_on_missing),
+        lambda match: env_replace(match, fail_on_missing, env_values),
         value,
     )
 
@@ -74,21 +83,22 @@ def process(
     item: TOMLValue,
     parse_float: ParseFloat,
     fail_on_missing: bool,
+    env_values: EnvironMap,
 ) -> None:
     if isinstance(item, dict):
         for key, val in item.items():
             if isinstance(val, (dict, list)):
-                process(val, parse_float, fail_on_missing)
+                process(val, parse_float, fail_on_missing, env_values)
             elif isinstance(val, str):
-                replaced = _replace_env_value(val, parse_float, fail_on_missing)
+                replaced = _replace_env_value(val, parse_float, fail_on_missing, env_values)
                 if replaced is not None:
                     item[key] = replaced
     elif isinstance(item, list):
         for index, val in enumerate(item):
             if isinstance(val, (dict, list)):
-                process(val, parse_float, fail_on_missing)
+                process(val, parse_float, fail_on_missing, env_values)
             elif isinstance(val, str):
-                replaced = _replace_env_value(val, parse_float, fail_on_missing)
+                replaced = _replace_env_value(val, parse_float, fail_on_missing, env_values)
                 if replaced is not None:
                     item[index] = replaced
 
@@ -99,6 +109,7 @@ def load(
     *,
     parse_float: ParseFloat = float,
     fail_on_missing: bool = False,
+    env_values: EnvironMap = None,
 ) -> dict[str, Any]:
     """Parse TOML from a binary file object and replace environment variables.
 
@@ -106,9 +117,10 @@ def load(
         fp: Binary file object to read.
         parse_float: Callable to parse TOML float values.
         fail_on_missing: Raise if an env var is missing or empty.
+        env_values: A mapping of env variable to value to use instead of os.environ
     """
     data = tomllib.load(fp, parse_float=parse_float)
-    process(data, parse_float, fail_on_missing)
+    process(data, parse_float, fail_on_missing, env_values)
     return data
 
 
@@ -118,6 +130,7 @@ def loads(
     *,
     parse_float: ParseFloat = float,
     fail_on_missing: bool = False,
+    env_values: EnvironMap = None,
 ) -> dict[str, Any]:
     """Parse TOML from a string and replace environment variables.
 
@@ -125,7 +138,8 @@ def loads(
         s: TOML string to parse.
         parse_float: Callable to parse TOML float values.
         fail_on_missing: Raise if an env var is missing or empty.
+        env_values: A mapping of env variable to value to use instead of os.environ
     """
     data = tomllib.loads(s, parse_float=parse_float)
-    process(data, parse_float, fail_on_missing)
+    process(data, parse_float, fail_on_missing, env_values)
     return data


### PR DESCRIPTION
Sometimes applications wish to not pollute os.environ when loading environment variables from a config, like with python dotenv's dotenv_values. This change allows us to override the specifically hard coded os.environ with our own custom mapping to facilitate this.

I am also aware that this could be "abused" beyond the originally intended usecase, and will extend envtoml into somewhat more of a templating engine. But it seems like a positive to allow users to pass in an arbitrary str -> str mapping for whatever use they may need.